### PR TITLE
Flip skip and bs argument values

### DIFF
--- a/DD_Create_and_Split.ps1
+++ b/DD_Create_and_Split.ps1
@@ -15,7 +15,7 @@ foreach($Game in $Games) {
 	}
 	
     $GameDD = "Games\" + $GameName + "_DD.iso"
-    ./dd.exe if=Games\$Game of=$GameDD skip=387k bs=1k
+    ./dd.exe if=Games\$Game of=$GameDD skip=1k bs=387k
  	./fSplit.exe -split 4094 mb "$GameDD" -f "Games\$GameName.{0}.iso"
 	
 	Remove-Item $GameDD


### PR DESCRIPTION
Flips the skip and bs argument values so that we skip 1k blocks with 387k size.
The benefit of this is that we skip fewer blocks, while at the same time we're writing bigger blocks out.

Non-scientific benchmarch in powershell shows a reduction in time from 24 seconds down to 2-3 seconds pr iso being processed by dd on my machine