### PR TITLE
Add support for expanding zip archives

### DIFF
--- a/DD_Create_and_Split.ps1
+++ b/DD_Create_and_Split.ps1
@@ -1,22 +1,38 @@
 $DeleteSource = "a"
+$ExpandArchives = "a"
 $Yes = @("Yes", "YES", "yes", "Y", "y")
 $No = @("No", "NO", "no", "N", "n")
 
+while(-not($Yes.contains($ExpandArchives) -or $No.contains($ExpandArchives))) {
+	$ExpandArchives = Read-Host -Prompt "Find and expand ZIP archives to Games folder? [Y]es or [N]o"
+}
+
 while(-not($Yes.contains($DeleteSource) -or $No.contains($DeleteSource))) {
-	$DeleteSource = Read-Host -Prompt "Delete Source? [Y]es or [N]o"
+	$DeleteSource = Read-Host -Prompt "Delete Source ISOs after processing? [Y]es or [N]o"
+}
+
+if($Yes.contains($ExpandArchives)) {
+	$Zips = Get-ChildItem -Path 'Games' -Filter *.zip -Recurse
+
+	foreach($zip in $Zips) {
+		write-output "Trying to expand archive: $($zip.FullName)"
+		Expand-Archive -LiteralPath $zip.FullName -DestinationPath "Games" -Force
+	}
 }
 
 $Games = Get-ChildItem -Path 'Games' -Filter *.iso
 
 foreach($Game in $Games) {
+	write-output "Processing $Game"
 	$GameName = $Game.BaseName
 	if($GameName.length -gt 36) {
         $GameName = $Game.Name.Substring(0,36)
+		write-output "Truncating filename to: $GameName"
 	}
 	
     $GameDD = "Games\" + $GameName + "_DD.iso"
-    ./dd.exe if=Games\$Game of=$GameDD skip=1k bs=387k
- 	./fSplit.exe -split 4094 mb "$GameDD" -f "Games\$GameName.{0}.iso"
+    & "$PSScriptRoot\dd.exe" @("if=Games\$Game", "of=$GameDD", "skip=387", "bs=1M")
+ 	& "$PSScriptRoot\fSplit.exe"  @('-split', 4094, 'mb', $GameDD, '-df', 'Games', '-f', "$GameName.{0}.iso")
 	
 	Remove-Item $GameDD
 	if($Yes.contains($DeleteSource)) {

--- a/README.md
+++ b/README.md
@@ -2,9 +2,11 @@ This script batch converts Xbox Redumps (complete disc rips from archive.org) to
 
 You will have the option to save the source isos or have them deleted.
 
-Place all full redump isos in the 'Games' directory and run the powershell script by double clicking DD_Create_and_Split.bat or running the following command:
+Place either all full redump isos or zip archives in the 'Games' directory and run the powershell script by double clicking DD_Create_and_Split.bat or running the following command:
 
 powershell -ExecutionPolicy ByPass -File .\DD_Create_and_Split.ps1
+
+By enabling expansion of archives the runtime will increase, but the benefit is that you can store your redumps as the original zip archive.
 
 This has no error handling and has only been tested on Windows 10. I can not vouch in any way for the provenance of fSplit.exe, fSplit.exe.config, xdvdfs_maker.exe, or dd.exe. This script comes with no guarantees or warranties. You can find me at:
 


### PR DESCRIPTION
Added support for finding and expanding zip archives to the root of the Games folder.
Added bypass to skip search and expand for zip archives
Changed execution of dd and fsplit to include the script root path, so that the script can be added to either path or your powershell profile.
Added some rudimentary logging of what's going on.